### PR TITLE
Fix releases schema

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-github',
-      version='2.0.0',
+      version='2.0.3',
       description='Singer.io tap for extracting data from the GitHub API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_github/schemas/releases.json
+++ b/tap_github/schemas/releases.json
@@ -2,9 +2,6 @@
   "type": ["null", "object"],
   "additionalProperties": false,
   "properties": {
-    "_sdc_repository": {
-      "type": ["string"]
-    },
     "id": {
       "type": ["null", "string"]
     },

--- a/tap_github/schemas/releases.json
+++ b/tap_github/schemas/releases.json
@@ -183,8 +183,7 @@
       "format": "date-time"
     },
     "discussion_url": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     }
   }
 }

--- a/tap_github/schemas/releases.json
+++ b/tap_github/schemas/releases.json
@@ -2,6 +2,9 @@
   "type": ["null", "object"],
   "additionalProperties": false,
   "properties": {
+    "_sdc_repository": {
+      "type": ["string"]
+    },
     "id": {
       "type": ["null", "string"]
     },


### PR DESCRIPTION
# Description of change
Removing `discussion_url` `format` since it should be uri and not date-time according to API docs https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28

# Manual QA steps
 - Manually tested using meltano cli.
```
meltano elt tap-github target-jsonl --select releases
``` 
# Risks
 - 
 
# Rollback steps
 - revert this branch
