### PR TITLE
Not skip 404 on verify repo access

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-github',
-      version='2.0.4',
+      version='2.0.5',
       description='Singer.io tap for extracting data from the GitHub API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -247,7 +247,7 @@ class GithubClient:
         Call rest API to verify that the user has sufficient permissions to access this repository.
         """
         try:
-            self.authed_get("verifying repository access", url_for_repo)
+            self.authed_get("verifying repository access", url_for_repo, should_skip_404=False)
         except NotFoundException:
             # Throwing user-friendly error message as it checks token access
             message = "HTTP-error-code: 404, Error: Please check the repository name \'{}\' or you do not have sufficient permissions to access this repository.".format(repo)

--- a/tests/unittests/test_verify_access.py
+++ b/tests/unittests/test_verify_access.py
@@ -60,3 +60,15 @@ class TestCredentials(unittest.TestCase):
 
         # Verify error with proper message
         self.assertEqual(str(e.exception), "HTTP-error-code: 401, Error: {}".format(json))
+
+    def test_repo_no_permission(self, mocked_parse_args, mocked_request, mock_verify_access):
+        """Verify if 404 error arises"""
+        test_client = GithubClient(self.config)
+        json = {"message": "Please check the repository name 'repo' or you do not have sufficient permissions to access this repository.", "documentation_url": "https://docs.github.com/"}
+        mocked_request.return_value = get_response(404, json, True)
+
+        with self.assertRaises(tap_github.client.NotFoundException) as e:
+            test_client.verify_repo_access("", "repo")
+
+        # Verify error with proper message
+        self.assertEqual(str(e.exception), "HTTP-error-code: 404, Error: {}".format(json['message']))


### PR DESCRIPTION
# Description of change
This PR removes the skip 404 in the `verify_repo_access` to force the sync to be terminated with an exception in case of the user doesn't have sufficient permissions. 

- Before:
```
 $ meltano el tap-github target-jsonl --select issues
...
2023-11-23T14:27:45.119236Z [info     ] WARNING Please check the repository name '******' or you do not have sufficient permissions to access this repository for following streams issues. 
2023-11-23T14:27:45.160501Z [info     ] Extract & load complete! 
2023-11-23T14:27:45.160605Z [info     ] Transformation skipped.  

# echo $?
0
```

- After:
```
 $ meltano el tap-github target-jsonl --select issues
...
CRITICAL HTTP-error-code: 404, Error: Please check the repository name '******' or you do not have sufficient permissions to access this repository.

# echo $?
1
```

# Manual QA steps
 - Run unit test
 
# Risks
 - None
 
# Rollback steps
 - revert this branch
