### PR TITLE
Revert "Remove the exception if no X-RateLimit-Remaining is found in the header"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-github',
-      version='2.0.7',
+      version='2.0.6',
       description='Singer.io tap for extracting data from the GitHub API',
       author='Stitch',
       url='http://singer.io',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-github',
-      version='2.0.6',
+      version='2.0.8',
       description='Singer.io tap for extracting data from the GitHub API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -160,6 +160,10 @@ def rate_throttling(response, max_sleep_seconds, min_remain_rate_limit):
 
             LOGGER.info("API rate limit exceeded. Tap will retry the data collection after %s seconds.", seconds_to_sleep)
             time.sleep(seconds_to_sleep)
+    else:
+        # Raise an exception if `X-RateLimit-Remaining` is not found in the header.
+        # API does include this key header if provided base URL is not a valid github custom domain.
+        raise GithubException("The API call using the specified base url was unsuccessful. Please double-check the provided base URL.")
 
 class GithubClient:
     """


### PR DESCRIPTION
Reverts Automattic/tap-github#8

Github team has fixed this issue:  https://github.com/orgs/community/discussions/140079#discussioncomment-10843669