### PR TITLE
Fix: Avoid write empty state

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,23 +3,23 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-github',
-      version='2.0.9',
+      version='2.1.0',
       description='Singer.io tap for extracting data from the GitHub API',
       author='Stitch',
       url='http://singer.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_github'],
       install_requires=[
-          'singer-python==5.12.1',
-          'requests==2.20.0',
-          'backoff==1.8.0'
+          'singer-python==v6.1.0',
+          'requests==2.32.3',
+          'backoff==2.2.1'
       ],
       extras_require={
           'dev': [
-              'pylint==2.6.2',
+              'pylint==3.3.4',
               'ipdb',
               'nose',
-              'requests-mock==1.9.3'
+              'requests-mock==1.7.0'
           ]
       },
       entry_points='''

--- a/tap_github/sync.py
+++ b/tap_github/sync.py
@@ -30,8 +30,6 @@ def update_currently_syncing(state, stream_name):
         del state['currently_syncing']
     else:
         singer.set_currently_syncing(state, stream_name)
-    if state:
-        singer.write_state(state)
 
 def update_currently_syncing_repo(state, repo_path):
     """
@@ -42,8 +40,6 @@ def update_currently_syncing_repo(state, repo_path):
         del state['currently_syncing_repo']
     else:
         state['currently_syncing_repo'] = repo_path
-    if state:
-        singer.write_state(state)
 
 def get_ordered_stream_list(currently_syncing, streams_to_sync):
     """

--- a/tap_github/sync.py
+++ b/tap_github/sync.py
@@ -30,6 +30,7 @@ def update_currently_syncing(state, stream_name):
         del state['currently_syncing']
     else:
         singer.set_currently_syncing(state, stream_name)
+    write_state(state)
 
 def update_currently_syncing_repo(state, repo_path):
     """
@@ -40,6 +41,7 @@ def update_currently_syncing_repo(state, repo_path):
         del state['currently_syncing_repo']
     else:
         state['currently_syncing_repo'] = repo_path
+    write_state(state)
 
 def get_ordered_stream_list(currently_syncing, streams_to_sync):
     """
@@ -166,6 +168,11 @@ def write_schemas(stream_id, catalog, selected_streams):
     for child in stream_obj.children:
         write_schemas(child, catalog, selected_streams)
 
+def write_state(state):
+    if state and 'bookmarks' in state:
+        # Only write state if it is not empty.
+        singer.write_state(state)
+
 def sync(client, config, state, catalog):
     """
     Sync selected streams.
@@ -182,8 +189,7 @@ def sync(client, config, state, catalog):
     repositories, organizations = client.extract_repos_from_config()
 
     state = translate_state(state, catalog, repositories)
-    if state:
-        singer.write_state(state)
+    write_state(state)
 
     # Sync `teams`, `team_members`and `team_memberships` streams just single time for any organization.
     streams_to_sync_for_orgs = set(streams_to_sync).intersection(STREAM_TO_SYNC_FOR_ORGS)
@@ -230,6 +236,5 @@ def do_sync(catalog, streams_to_sync, selected_stream_ids, client, start_date, s
                                               selected_stream_ids = selected_stream_ids,
                                               stream_to_sync = streams_to_sync
                                             )
-            if state:
-                singer.write_state(state)
+            write_state(state)
         update_currently_syncing(state, None)

--- a/tap_github/sync.py
+++ b/tap_github/sync.py
@@ -28,7 +28,6 @@ def update_currently_syncing(state, stream_name):
     """
     if not stream_name and singer.get_currently_syncing(state):
         del state['currently_syncing']
-        singer.write_state(state)
     else:
         singer.set_currently_syncing(state, stream_name)
     if state:
@@ -41,7 +40,6 @@ def update_currently_syncing_repo(state, repo_path):
     """
     if (not repo_path) and ('currently_syncing_repo' in state):
         del state['currently_syncing_repo']
-        singer.write_state(state)
     else:
         state['currently_syncing_repo'] = repo_path
     if state:

--- a/tap_github/sync.py
+++ b/tap_github/sync.py
@@ -28,6 +28,7 @@ def update_currently_syncing(state, stream_name):
     """
     if not stream_name and singer.get_currently_syncing(state):
         del state['currently_syncing']
+        singer.write_state(state)
     else:
         singer.set_currently_syncing(state, stream_name)
     if state:
@@ -40,6 +41,7 @@ def update_currently_syncing_repo(state, repo_path):
     """
     if (not repo_path) and ('currently_syncing_repo' in state):
         del state['currently_syncing_repo']
+        singer.write_state(state)
     else:
         state['currently_syncing_repo'] = repo_path
     if state:

--- a/tap_github/sync.py
+++ b/tap_github/sync.py
@@ -169,7 +169,7 @@ def write_schemas(stream_id, catalog, selected_streams):
         write_schemas(child, catalog, selected_streams)
 
 def write_state(state):
-    if state and 'bookmarks' in state:
+    if state:
         # Only write state if it is not empty.
         singer.write_state(state)
 

--- a/tap_github/sync.py
+++ b/tap_github/sync.py
@@ -30,7 +30,8 @@ def update_currently_syncing(state, stream_name):
         del state['currently_syncing']
     else:
         singer.set_currently_syncing(state, stream_name)
-    singer.write_state(state)
+    if state:
+        singer.write_state(state)
 
 def update_currently_syncing_repo(state, repo_path):
     """
@@ -41,7 +42,8 @@ def update_currently_syncing_repo(state, repo_path):
         del state['currently_syncing_repo']
     else:
         state['currently_syncing_repo'] = repo_path
-    singer.write_state(state)
+    if state:
+        singer.write_state(state)
 
 def get_ordered_stream_list(currently_syncing, streams_to_sync):
     """
@@ -184,7 +186,8 @@ def sync(client, config, state, catalog):
     repositories, organizations = client.extract_repos_from_config()
 
     state = translate_state(state, catalog, repositories)
-    singer.write_state(state)
+    if state:
+        singer.write_state(state)
 
     # Sync `teams`, `team_members`and `team_memberships` streams just single time for any organization.
     streams_to_sync_for_orgs = set(streams_to_sync).intersection(STREAM_TO_SYNC_FOR_ORGS)
@@ -231,6 +234,6 @@ def do_sync(catalog, streams_to_sync, selected_stream_ids, client, start_date, s
                                               selected_stream_ids = selected_stream_ids,
                                               stream_to_sync = streams_to_sync
                                             )
-
-            singer.write_state(state)
+            if state:
+                singer.write_state(state)
         update_currently_syncing(state, None)


### PR DESCRIPTION
# Description of change
As this extractor doesn't use the Meltano singer SDK, this [PR](https://github.com/meltano/sdk/pull/2844) will not work as the states are manually written.

# Manual QA steps
 - Manually tested.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
