### PR TITLE
Add fail-fast check for archived repositories

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -3,5 +3,6 @@
     "repository": "singer-io/target-stitch",
     "start_date": "2021-01-01T00:00:00Z",
     "request_timeout": 300,
-    "base_url": "https://api.github.com"
+    "base_url": "https://api.github.com",
+    "extract_archived": "false"
 }

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-github',
-      version='2.0.13',
+      version='2.0.14',
       description='Singer.io tap for extracting data from the GitHub API',
       author='Stitch',
       url='http://singer.io',


### PR DESCRIPTION
Add validation to detect archived repositories during discovery and sync phases. The extraction will fail with ArchivedRepositoryError if a repository is archived, unless 'extract_archived' is set to 'true' in the config.

Changes:
- Add ArchivedRepositoryError exception class
- Add extract_archived config option (default: false)
- Add check_repo_archived() method to verify repo status via GitHub API
- Integrate archived check into verify_access_for_repo()
- Handle archived repos efficiently in get_all_repos() for org/* wildcards

# Description of change
(write a short description or paste a link to JIRA)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
